### PR TITLE
Allows deploying MHA to multiple nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ a look at it for sure!
 Feel free to open any issue you find too (but a PR is always better :P )
 
 ## Release Notes/Contributors/Etc
+Release 0.2.0
+ - Allows deploying multiple MHA nodes
+ - Fixed syntax issues in templates
 
 Release 0.1.1
  - Linter fixes

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -11,6 +11,8 @@
 #
 # https://code.google.com/p/mysql-master-ha/wiki/Parameters
 #
+# [*manager_name*]
+#   Name of the MHA manager
 # [*mha_conf_dir*]
 #   Base directory for MHA configuration file. Usually under /etc
 # [*workdir*]
@@ -86,6 +88,7 @@
 # Copyright 2015 Trovit Search S.L.
 #
 class mha::manager (
+  $manager_name                   = $mha::params::manager_name,
   $mha_conf_dir                   = $mha::params::mha_conf_dir,
   $workdir                        = $mha::params::workdir,
   $user                           = $mha::params::user,
@@ -134,7 +137,7 @@ class mha::manager (
 
   @@file { $workdir:
     ensure => directory,
-    tag    => 'mha_workdir'
+    tag    => "mha_workdir_${manager_name}"
   }
 
   file { "${mha_conf_dir}/scripts":

--- a/manifests/manager/instance.pp
+++ b/manifests/manager/instance.pp
@@ -13,6 +13,9 @@
 # [*cluster_name*] NAMEVAR
 #   String.
 #   Specify the cluster name ID. Do not use spaces.
+# [*manager_name*]
+#   String.
+#   Specify the name of the MHA manager.
 # [*servers*]
 #   Hash.
 #   An hash of servers that compose the cluser. Be careful: the hash key should always be in 
@@ -81,6 +84,7 @@ define mha::manager::instance (
   $ssh_key_pub,
   $ssh_key_type,
   $master_binlog_dir,
+  $manager_name           = 'mha',
   $cluster_name           = $name,
   $user_home              = '/root',
   $ssh_user               = 'root',
@@ -95,7 +99,7 @@ define mha::manager::instance (
   $daemon                 = false
 ) {
 
-  include mha::manager
+  ensure_resource('class', 'mha::manager', { 'manager_name' => $manager_name } )
 
   if ( $manager_log == '' or $manager_log == undef) {
     $real_manager_log = "/var/log/masterha_${cluster_name}.log"
@@ -143,7 +147,7 @@ define mha::manager::instance (
     require => File[$mha::manager::workdir]
   }
 
-  File <<| tag == 'mha_workdir' |>>
+  File <<| tag == "mha_workdir_${manager_name}" |>>
   File <<| tag == "mha_${cluster_name}_manager" |>>
 
   $mha_cluster_scripts_dir = "${mha::manager::mha_conf_dir}/scripts/${cluster_name}"

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -1,11 +1,15 @@
 # mha::node
-class mha::node ( $cluster_name ) {
+class mha::node (
+  $manager_name,
+  $cluster_name,
+){
 
   package { 'mha4mysql-node':
     ensure => installed
   }
 
-  File <<| tag == 'mha_workdir' |>>
+  File <<| tag == "mha_workdir_${manager_name}" |>>
+
   File <<| tag == "mha_${cluster_name}" |>>
   Ssh_authorized_key <<| tag == "mha_${cluster_name}" |>>
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,4 +32,5 @@ class mha::params {
   $init_conf_load_script = ''
   $remote_workdir = ''
   $master_binlog_dir = ''
+  $manager_name = 'mha'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "trovit-mha",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "Trovit Systems",
   "summary": "Manage MHA for MySQL install and configuration",
   "license": "GPL-3.0",

--- a/templates/masterha_default.cnf.erb
+++ b/templates/masterha_default.cnf.erb
@@ -16,7 +16,7 @@ ssh_options=<%= @ssh_options %>
 skip_reset_slave=<%= @skip_reset_slave %>
 <% end -%>
 <% if @mysql_user != '' -%>
-user = <%= @mysql_user %>
+user=<%= @mysql_user %>
 <% end -%>
 <% if @mysql_password != '' -%>
 password=<%= @mysql_password %>

--- a/templates/mha.conf.erb
+++ b/templates/mha.conf.erb
@@ -9,7 +9,7 @@ repl_user=<%= @mysql_repl_user %>
 repl_password=<%= @mysql_repl_password %>
 
 ssh_user=<%= @ssh_user %>
-ssh_options="<%= real_ssh_options %>"
+ssh_options="<%= @real_ssh_options %>"
 
 # working directory on the manager
 manager_workdir=<%= scope['mha::manager::workdir'] %>/<%= @cluster_name %>
@@ -30,11 +30,11 @@ master_ip_failover_script=<%= @mha_failover_path %>
 report_script=<%= @mha_report_path %>
 <% end -%>
 
-<% extra_options.sort_by { |key, value_hash| key}.each do |key, value_hash| -%>
+<% @extra_options.sort_by { |key, value_hash| key}.each do |key, value_hash| -%>
 <%= key %>=<%= value_hash %>
 <% end -%>
 
-<% servers.sort_by {|key, value_hash| key}.each do |key, value_hash| -%>
+<% @servers.sort_by { |key, value_hash| key}.each do |key, value_hash| -%>
 [<%= key %>]
 <% value_hash.sort_by {|parameter, param_value| parameter}.each do |parameter, param_value| -%>
 <%= parameter %>=<%= param_value %>


### PR DESCRIPTION
Introduced new parameter 'manager_name' for each new MHA manager node being deployed. This prevents name collision on 'mha_workdir'.
Fixed syntax issues in template files.